### PR TITLE
Implement keyword-based positioning of ellipsis / truncation point

### DIFF
--- a/dist/smart-truncate.es5.js
+++ b/dist/smart-truncate.es5.js
@@ -3,23 +3,26 @@
 /**
  * smartTruncate - Smartly™ truncate a given string.
  *
- * @param  {String} string - A string with a minimum lenght of 4 chars.
+ * @param  {String} string - A string with a minimum length of 4 chars.
  * @param  {Number} length - The length of the truncated result.
  * @param  {Object} [options]
- * @param  {Number} [options.position] - The index of the ellipsis (zero based).
- *                                      Default is the end.
+ * @param  {(Number|String)} [options.position='right']
+ *                         - The index of the ellipsis (zero based) or a string
+ *                           indicating position: 'left', 'center', or 'right'.
+ *                           Default is 'right'.
  * @param  {String} [options.mark = '…'] - The character[s] indicating omission.
  * @return {String} - Return a truncated string w/ ellipsis or a custom mark.
  *
  * Example: smartTruncate('Steve Miller', 8) === 'Steve M…'.
  * Example: smartTruncate('Steve Miller', 9, {position: 4}) === 'Stev…ller'.
+ * Example: smartTruncate('Steve Miller', 7, {position: 'left'}) === '…Miller'.
  */
 var smartTruncate = function smartTruncate(string, length) {
     var _ref = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {},
         _ref$mark = _ref.mark,
         mark = _ref$mark === undefined ? '\u2026' : _ref$mark,
         _ref$position = _ref.position,
-        position = _ref$position === undefined ? length - 1 : _ref$position;
+        position = _ref$position === undefined ? 'right' : _ref$position;
 
     if (typeof mark !== 'string') return string;
 
@@ -36,9 +39,20 @@ var smartTruncate = function smartTruncate(string, length) {
 
     if (invalid) return string;
 
-    if (position >= length - markOffset) {
+    if (position >= length - markOffset || position === 'right') {
         var _start = str.substring(0, length - markOffset);
         return '' + _start + mark;
+    }
+
+    if (position === 'left') {
+        var _end = str.substring(str.length - (length - 1), str.length);
+        return '' + mark + _end;
+    }
+
+    if (position === 'center') {
+        var _start2 = str.substring(0, length / 2);
+        var _end2 = str.substring(str.length - length / 2 + 1, str.length);
+        return '' + _start2 + mark + _end2;
     }
 
     var start = str.substring(0, position);

--- a/src/smart-truncate.js
+++ b/src/smart-truncate.js
@@ -1,21 +1,24 @@
 /**
  * smartTruncate - Smartly™ truncate a given string.
  *
- * @param  {String} string - A string with a minimum lenght of 4 chars.
+ * @param  {String} string - A string with a minimum length of 4 chars.
  * @param  {Number} length - The length of the truncated result.
  * @param  {Object} [options]
- * @param  {Number} [options.position] - The index of the ellipsis (zero based).
- *                                      Default is the end.
+ * @param  {(Number|String)} [options.position='right']
+ *                         - The index of the ellipsis (zero based) or a string
+ *                           indicating position: 'left', 'center', or 'right'.
+ *                           Default is 'right'.
  * @param  {String} [options.mark = '…'] - The character[s] indicating omission.
  * @return {String} - Return a truncated string w/ ellipsis or a custom mark.
  *
  * Example: smartTruncate('Steve Miller', 8) === 'Steve M…'.
  * Example: smartTruncate('Steve Miller', 9, {position: 4}) === 'Stev…ller'.
+ * Example: smartTruncate('Steve Miller', 7, {position: 'left'}) === '…Miller'.
  */
 const smartTruncate = (string, length,
     {
         mark = '\u2026', // ellipsis = …
-        position = (length - 1),
+        position = 'right',
     } = {}
 ) => {
     if (typeof mark !== 'string') return string;
@@ -37,9 +40,20 @@ const smartTruncate = (string, length,
 
     if (invalid) return string;
 
-    if (position >= (length - markOffset)) {
+    if (position >= (length - markOffset) || position === 'right') {
         const start = str.substring(0, length - markOffset);
         return `${start}${mark}`;
+    }
+
+    if (position === 'left') {
+        const end = str.substring(str.length - (length - 1), str.length);
+        return `${mark}${end}`;
+    }
+
+    if (position === 'center') {
+        const start = str.substring(0, length / 2);
+        const end = str.substring(str.length - (length / 2) + 1, str.length);
+        return `${start}${mark}${end}`;
     }
 
     const start = str.substring(0, position);

--- a/src/smart-truncate.spec.js
+++ b/src/smart-truncate.spec.js
@@ -129,7 +129,7 @@ describe('smartTruncate()', () => {
     it('should return truncated string with ellipsis at the left end of the string if specified', () => {
         const expected = '…jumped over the lazy dog';
 
-        let result = smartTruncate('A quick brown fox jumped over the lazy dog', 25, {
+        const result = smartTruncate('A quick brown fox jumped over the lazy dog', 25, {
             position: 'left',
         });
         expect(result).to.equal(expected);
@@ -138,11 +138,17 @@ describe('smartTruncate()', () => {
 
     // ref: https://github.com/millerized/smart-truncate/issues/10
     it('should return truncated string with ellipsis at the center of the string if specified', () => {
-        const expected = 'A quick brown…the lazy dog';
+        let expected = 'A quick brown…the lazy dog';
 
         let result = smartTruncate('A quick brown fox jumped over the lazy dog', 26, {
             position: 'center',
         });
+        expect(result).to.equal(expected);
+        expect(result.length).to.equal(expected.length);
+
+        expected = 'It was the best of time… the age of foolishness';
+        const twoCities = 'It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness';
+        result = smartTruncate(twoCities, 47, {position: 'center'});
         expect(result).to.equal(expected);
         expect(result.length).to.equal(expected.length);
     });

--- a/src/smart-truncate.spec.js
+++ b/src/smart-truncate.spec.js
@@ -108,4 +108,42 @@ describe('smartTruncate()', () => {
         expect(result).to.equal(expected);
         expect(result.length).to.equal(expected.length);
     });
+
+    // ref: https://github.com/millerized/smart-truncate/issues/10
+    it('should return truncated string with ellipsis at the right end of the string by default / if specified', () => {
+        const expected = 'A quick brown fox…';
+
+        let result = smartTruncate('A quick brown fox jumped over the lazy dog', 18);
+        expect(result).to.equal(expected);
+        expect(result.length).to.equal(expected.length);
+
+        result = smartTruncate('A quick brown fox jumped over the lazy dog', 18, {
+            position: 'right',
+        });
+
+        expect(result).to.equal(expected);
+        expect(result.length).to.equal(expected.length);
+    });
+
+    // ref: https://github.com/millerized/smart-truncate/issues/10
+    it('should return truncated string with ellipsis at the left end of the string if specified', () => {
+        const expected = '…jumped over the lazy dog';
+
+        let result = smartTruncate('A quick brown fox jumped over the lazy dog', 25, {
+            position: 'left',
+        });
+        expect(result).to.equal(expected);
+        expect(result.length).to.equal(expected.length);
+    });
+
+    // ref: https://github.com/millerized/smart-truncate/issues/10
+    it('should return truncated string with ellipsis at the center of the string if specified', () => {
+        const expected = 'A quick brown…the lazy dog';
+
+        let result = smartTruncate('A quick brown fox jumped over the lazy dog', 26, {
+            position: 'center',
+        });
+        expect(result).to.equal(expected);
+        expect(result.length).to.equal(expected.length);
+    });
 });


### PR DESCRIPTION
In response to [#10](https://github.com/millerized/smart-truncate/issues/10).

## Feature
Allows user to specify placement of truncation marker (default ellipsis) using a relative keyword 'left', 'center', or 'right'.

## Examples
```javascript
smartTruncate('A quick brown fox jumped over the lazy dog', 18, {position: 'right'});
// returns 'A quick brown fox…'

smartTruncate('A quick brown fox jumped over the lazy dog', 25, {position: 'left'});
// returns '…jumped over the lazy dog'

smartTruncate('A quick brown fox jumped over the lazy dog', 26, {position: 'center'});
// returns 'A quick brown…the lazy dog'
```

## Notes
I used a TDD approach, but the implementation is still rather naïve. I'm interested to see if the control flow could be cleaned up while maintaining legibility.